### PR TITLE
Remove sync methods in favor of __getattr__

### DIFF
--- a/devolo_plc_api/clients/protobuf.py
+++ b/devolo_plc_api/clients/protobuf.py
@@ -45,7 +45,7 @@ class Protobuf(ABC):
     async def _async_get(self, sub_url: str, timeout: float = TIMEOUT) -> Response:
         """ Query URL asynchronously. """
         url = f"{self.url}{sub_url}"
-        self._logger.debug(f"Getting from {url}")
+        self._logger.debug("Getting from %s", url)
         try:
             return await self._session.get(url,
                                            auth=DigestAuth(self._user, self._password),
@@ -56,7 +56,7 @@ class Protobuf(ABC):
     async def _async_post(self, sub_url: str, content: bytes, timeout: float = TIMEOUT) -> Response:
         """ Post data asynchronously. """
         url = f"{self.url}{sub_url}"
-        self._logger.debug(f"Posting to {url}")
+        self._logger.debug("Posting to %s", url)
         try:
             return await self._session.post(url,
                                             auth=DigestAuth(self._user, self._password),

--- a/devolo_plc_api/clients/protobuf.py
+++ b/devolo_plc_api/clients/protobuf.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from abc import ABC, abstractclassmethod
+from typing import Callable
 
 from google.protobuf.json_format import MessageToDict
 from httpx import AsyncClient, DigestAuth, Response
@@ -28,7 +29,7 @@ class Protobuf(ABC):
         self._user: str
         self._version: str
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Callable:
         """ Catch attempts to call methods synchronously. """
         def method(*args, **kwargs):
             return self._loop.run_until_complete(getattr(self, async_method)(*args, **kwargs))

--- a/devolo_plc_api/clients/protobuf.py
+++ b/devolo_plc_api/clients/protobuf.py
@@ -1,9 +1,9 @@
-from abc import ABC
-from logging import Logger
-from typing import Union
+import asyncio
+import logging
+from abc import ABC, abstractclassmethod
 
 from google.protobuf.json_format import MessageToDict
-from httpx import AsyncClient, Client, DigestAuth, Response
+from httpx import AsyncClient, DigestAuth, Response
 
 from ..exceptions.device import DevicePasswordProtected
 
@@ -14,47 +14,42 @@ class Protobuf(ABC):
     """
     Google Protobuf client.
     """
-    _ip: str
-    _logger: Logger
-    _password: str
-    _path: str
-    _port: int
-    _session: Union[AsyncClient, Client]
-    _user: str
-    _version: str
 
+    @abstractclassmethod
+    def __init__(self):
+        self._loop = asyncio.get_running_loop()
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+        self._ip: str
+        self._password: str
+        self._path: str
+        self._port: int
+        self._session: AsyncClient
+        self._user: str
+        self._version: str
+
+    def __getattr__(self, attr):
+        """ Catch attempts to call methods synchronously. """
+        def method(*args, **kwargs):
+            return self._loop.run_until_complete(getattr(self, async_method)(*args, **kwargs))
+        async_method = f"async_{attr}"
+        if hasattr(self.__class__, async_method):
+            return method
+        raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
 
     @property
     def url(self) -> str:
         """ The base URL to query. """
         return f"http://{self._ip}:{self._port}/{self._path}/{self._version}/"
 
-
-    @staticmethod
-    def _message_to_dict(message) -> dict:
-        """ Convert message to dict with certain settings. """
-        return MessageToDict(message=message, including_default_value_fields=True, preserving_proto_field_name=True)
-
-
     async def _async_get(self, sub_url: str, timeout: float = TIMEOUT) -> Response:
         """ Query URL asynchronously. """
         url = f"{self.url}{sub_url}"
         self._logger.debug(f"Getting from {url}")
         try:
-            return await self._session.get(url,  # type: ignore
+            return await self._session.get(url,
                                            auth=DigestAuth(self._user, self._password),
                                            timeout=timeout)
-        except TypeError:
-            raise DevicePasswordProtected("The used password is wrong.") from None
-
-    def _get(self, sub_url: str, timeout: float = TIMEOUT) -> Response:
-        """ Query URL synchronously. """
-        url = f"{self.url}{sub_url}"
-        self._logger.debug(f"Getting from {url}")
-        try:
-            return self._session.get(url,  # type: ignore
-                                     auth=DigestAuth(self._user, self._password),
-                                     timeout=timeout)
         except TypeError:
             raise DevicePasswordProtected("The used password is wrong.") from None
 
@@ -63,21 +58,14 @@ class Protobuf(ABC):
         url = f"{self.url}{sub_url}"
         self._logger.debug(f"Posting to {url}")
         try:
-            return await self._session.post(url,  # type: ignore
+            return await self._session.post(url,
                                             auth=DigestAuth(self._user, self._password),
                                             content=content,
                                             timeout=timeout)
         except TypeError:
             raise DevicePasswordProtected("The used password is wrong.") from None
 
-    def _post(self, sub_url: str, content: bytes, timeout: float = TIMEOUT) -> Response:
-        """ Post data synchronously. """
-        url = f"{self.url}{sub_url}"
-        self._logger.debug(f"Posting to {url}")
-        try:
-            return self._session.post(url,  # type: ignore
-                                      auth=DigestAuth(self._user, self._password),
-                                      content=content,
-                                      timeout=timeout)
-        except TypeError:
-            raise DevicePasswordProtected("The used password is wrong.") from None
+    @staticmethod
+    def _message_to_dict(message) -> dict:
+        """ Convert message to dict with certain settings. """
+        return MessageToDict(message=message, including_default_value_fields=True, preserving_proto_field_name=True)

--- a/devolo_plc_api/plcnet_api/plcnetapi.py
+++ b/devolo_plc_api/plcnet_api/plcnetapi.py
@@ -1,7 +1,4 @@
-import logging
-from typing import Union
-
-from httpx import AsyncClient, Client
+from httpx import AsyncClient
 
 from ..clients.protobuf import Protobuf
 from . import (devolo_idl_proto_plcnetapi_getnetworkoverview_pb2,
@@ -24,10 +21,11 @@ class PlcNetApi(Protobuf):
     def __init__(self,
                  ip: str,
                  port: int,
-                 session: Union[AsyncClient, Client],
+                 session: AsyncClient,
                  path: str,
                  version: str,
                  mac: str):
+        super().__init__()
         self._ip = ip
         self._port = port
         self._session = session
@@ -36,12 +34,10 @@ class PlcNetApi(Protobuf):
         self._mac = mac
         self._user = ""  # PLC API is not password protected.
         self._password = ""  # PLC API is not password protected.
-        self._logger = logging.getLogger(self.__class__.__name__)
-
 
     async def async_get_network_overview(self) -> dict:
         """
-        Get a PLC network overview asynchronously.
+        Get a PLC network overview.
 
         :return: Network overview
         """
@@ -51,21 +47,9 @@ class PlcNetApi(Protobuf):
         network_overview.ParseFromString(await response.aread())
         return self._message_to_dict(network_overview)
 
-    def get_network_overview(self) -> dict:
+    async def async_identify_device_start(self) -> bool:
         """
-        Get a PLC network overview synchronously.
-
-        :return: Network overview
-        """
-        self._logger.debug("Getting network overview.")
-        network_overview = devolo_idl_proto_plcnetapi_getnetworkoverview_pb2.GetNetworkOverview()
-        response = self._get("GetNetworkOverview")
-        network_overview.ParseFromString(response.read())
-        return self._message_to_dict(network_overview)
-
-    async def async_identify_device_start(self):
-        """
-        Make PLC LED of a device blick to identify it asynchronously.
+        Make PLC LED of a device blick to identify it.
 
         :return: True, if identifying was successfully started, otherwise False
         """
@@ -77,23 +61,9 @@ class PlcNetApi(Protobuf):
         response.FromString(await query.aread())  # pylint: disable=no-member
         return bool(not response.result)  # pylint: disable=no-member
 
-    def identify_device_start(self):
+    async def async_identify_device_stop(self) -> bool:
         """
-        Make PLC LED of a device blick to identify it synchronously.
-
-        :return: True, if identifying was successfully started, otherwise False
-        """
-        self._logger.debug("Starting LED blinking.")
-        identify_device = devolo_idl_proto_plcnetapi_identifydevice_pb2.IdentifyDeviceStart()
-        identify_device.mac_address = self._mac
-        query = self._post("IdentifyDeviceStart", content=identify_device.SerializeToString())
-        response = devolo_idl_proto_plcnetapi_identifydevice_pb2.IdentifyDeviceResponse()
-        response.FromString(query.read())  # pylint: disable=no-member
-        return bool(not response.result)  # pylint: disable=no-member
-
-    async def async_identify_device_stop(self):
-        """
-        Stop the PLC LED blicking asynchronously.
+        Stop the PLC LED blicking.
 
         :return: True, if identifying was successfully stopped, otherwise False
         """
@@ -105,23 +75,9 @@ class PlcNetApi(Protobuf):
         response.FromString(await query.aread())  # pylint: disable=no-member
         return bool(not response.result)  # pylint: disable=no-member
 
-    def identify_device_stop(self):
-        """
-        Stop the PLC LED blicking synchronously.
-
-        :return: True, if identifying was successfully stopped, otherwise False
-        """
-        self._logger.debug("Stopping LED blinking.")
-        identify_device = devolo_idl_proto_plcnetapi_identifydevice_pb2.IdentifyDeviceStop()
-        identify_device.mac_address = self._mac
-        query = self._post("IdentifyDeviceStop", content=identify_device.SerializeToString())
-        response = devolo_idl_proto_plcnetapi_identifydevice_pb2.IdentifyDeviceResponse()
-        response.FromString(query.read())  # pylint: disable=no-member
-        return bool(not response.result)  # pylint: disable=no-member
-
     async def async_set_user_device_name(self, name):
         """
-        Set device name asynchronously.
+        Set device name.
 
         :param name: Name, the device shall have
         :return: True, if the device was successfully renamed, otherwise False
@@ -133,20 +89,4 @@ class PlcNetApi(Protobuf):
         query = await self._async_post("SetUserDeviceName", content=set_user_name.SerializeToString(), timeout=10.0)
         response = devolo_idl_proto_plcnetapi_setuserdevicename_pb2.SetUserDeviceNameResponse()
         response.FromString(await query.aread())  # pylint: disable=no-member
-        return bool(not response.result)  # pylint: disable=no-member
-
-    def set_user_device_name(self, name):
-        """
-        Set device name synchronously.
-
-        :param name: Name, the device shall have
-        :return: True, if the device was successfully renamed, otherwise False
-        """
-        self._logger.debug("Setting device name.")
-        set_user_name = devolo_idl_proto_plcnetapi_setuserdevicename_pb2.SetUserDeviceName()
-        set_user_name.mac_address = self._mac
-        set_user_name.user_device_name = name
-        query = self._post("SetUserDeviceName", content=set_user_name.SerializeToString(), timeout=10.0)
-        response = devolo_idl_proto_plcnetapi_setuserdevicename_pb2.SetUserDeviceNameResponse()
-        response.FromString(query.read())  # pylint: disable=no-member
         return bool(not response.result)  # pylint: disable=no-member

--- a/tests/fixtures/device_api.py
+++ b/tests/fixtures/device_api.py
@@ -1,8 +1,9 @@
+import asyncio
 from unittest.mock import patch
 
 import pytest
 from devolo_plc_api.device_api.deviceapi import DeviceApi
-from httpx import AsyncClient, Client, Response
+from httpx import AsyncClient, Response
 
 try:
     from unittest.mock import AsyncMock
@@ -11,25 +12,14 @@ except ImportError:
 
 
 @pytest.fixture()
-def device_api_async(request, feature):
+def device_api(request, feature):
     with patch("devolo_plc_api.clients.protobuf.Protobuf._async_get", new=AsyncMock(return_value=Response)), \
-         patch("devolo_plc_api.clients.protobuf.Protobuf._async_post", new=AsyncMock(return_value=Response)):
+         patch("devolo_plc_api.clients.protobuf.Protobuf._async_post", new=AsyncMock(return_value=Response)), \
+         patch("asyncio.get_running_loop", asyncio.new_event_loop):
+        asyncio.new_event_loop()
         yield DeviceApi(request.cls.ip,
                         request.cls.device_info['_dvl-deviceapi._tcp.local.']['Port'],
                         AsyncClient(),
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Path'],
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Version'],
-                        feature,
-                        "password")
-
-
-@pytest.fixture()
-def device_api_sync(request, feature):
-    with patch("devolo_plc_api.clients.protobuf.Protobuf._get", return_value=Response), \
-         patch("devolo_plc_api.clients.protobuf.Protobuf._post", return_value=Response):
-        yield DeviceApi(request.cls.ip,
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Port'],
-                        Client(),
                         request.cls.device_info['_dvl-deviceapi._tcp.local.']['Path'],
                         request.cls.device_info['_dvl-deviceapi._tcp.local.']['Version'],
                         feature,

--- a/tests/fixtures/plcnet_api.py
+++ b/tests/fixtures/plcnet_api.py
@@ -1,8 +1,9 @@
+import asyncio
 from unittest.mock import patch
 
 import pytest
 from devolo_plc_api.plcnet_api.plcnetapi import PlcNetApi
-from httpx import AsyncClient, Client, Response
+from httpx import AsyncClient, Response
 
 try:
     from unittest.mock import AsyncMock
@@ -11,24 +12,14 @@ except ImportError:
 
 
 @pytest.fixture()
-def plcnet_api_async(request):
+def plcnet_api(request):
     with patch("devolo_plc_api.clients.protobuf.Protobuf._async_get", new=AsyncMock(return_value=Response)), \
-         patch("devolo_plc_api.clients.protobuf.Protobuf._async_post", new=AsyncMock(return_value=Response)):
+         patch("devolo_plc_api.clients.protobuf.Protobuf._async_post", new=AsyncMock(return_value=Response)), \
+         patch("asyncio.get_running_loop", asyncio.new_event_loop):
+        asyncio.new_event_loop()
         yield PlcNetApi(request.cls.ip,
                         request.cls.device_info['_dvl-deviceapi._tcp.local.']['Port'],
                         AsyncClient(),
-                        request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Path'],
-                        request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Version'],
-                        request.cls.device_info['_dvl-plcnetapi._tcp.local.']['PlcMacAddress'])
-
-
-@pytest.fixture()
-def plcnet_api_sync(request):
-    with patch("devolo_plc_api.clients.protobuf.Protobuf._get", return_value=Response), \
-         patch("devolo_plc_api.clients.protobuf.Protobuf._post", return_value=Response):
-        yield PlcNetApi(request.cls.ip,
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Port'],
-                        Client(),
                         request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Path'],
                         request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Version'],
                         request.cls.device_info['_dvl-plcnetapi._tcp.local.']['PlcMacAddress'])

--- a/tests/fixtures/protobuf.py
+++ b/tests/fixtures/protobuf.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 try:
@@ -7,37 +5,26 @@ try:
 except ImportError:
     from asynctest import CoroutineMock as AsyncMock
 
-from devolo_plc_api.clients.protobuf import Protobuf
+from ..stubs.protobuf import StubProtobuf
 
 
 @pytest.fixture()
-def mock_protobuf(request):
-    protobuf = Protobuf()
-    protobuf._logger = logging.getLogger("ProtobufMock")
-    protobuf._ip = request.cls.ip
-    protobuf._port = 14791
-    protobuf._path = request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Path']
-    protobuf._version = request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Version']
-    protobuf._user = "user"
-    protobuf._password = "password"
-    return protobuf
+def mock_protobuf():
+    protobuf = StubProtobuf()
+    yield protobuf
 
 
 @pytest.fixture()
 def mock_get(mocker):
     mocker.patch("httpx.AsyncClient.get", new=AsyncMock())
-    mocker.patch("httpx.Client.get", return_value=None)
 
 
 @pytest.fixture()
 def mock_post(mocker):
     mocker.patch("httpx.AsyncClient.post", new=AsyncMock())
-    mocker.patch("httpx.Client.post", return_value=None)
 
 
 @pytest.fixture()
 def mock_wrong_password(mocker):
     mocker.patch("httpx.AsyncClient.get", side_effect=TypeError())
-    mocker.patch("httpx.Client.get", side_effect=TypeError())
     mocker.patch("httpx.AsyncClient.post", side_effect=TypeError())
-    mocker.patch("httpx.Client.post", side_effect=TypeError())

--- a/tests/stubs/protobuf.py
+++ b/tests/stubs/protobuf.py
@@ -1,0 +1,22 @@
+import asyncio
+import json
+import logging
+import pathlib
+
+from devolo_plc_api.clients.protobuf import Protobuf
+
+file = pathlib.Path(__file__).parent / "../test_data.json"
+with file.open("r") as fh:
+    test_data = json.load(fh)
+
+
+class StubProtobuf(Protobuf):
+    def __init__(self):
+        self._logger = logging.getLogger("ProtobufMock")
+        self._loop = asyncio.new_event_loop()
+        self._ip = test_data["ip"]
+        self._port = 14791
+        self._path = test_data["device_info"]["_dvl-plcnetapi._tcp.local."]["Path"]
+        self._version = test_data["device_info"]["_dvl-plcnetapi._tcp.local."]["Version"]
+        self._user = "user"
+        self._password = "password"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -18,16 +18,6 @@ from devolo_plc_api.plcnet_api.plcnetapi import PlcNetApi
 class TestDevice:
 
     @pytest.mark.asyncio
-    async def test__gather_apis(self, mocker, mock_device):
-        with patch("devolo_plc_api.device.Device._get_device_info", new=AsyncMock()), \
-             patch("devolo_plc_api.device.Device._get_plcnet_info", new=AsyncMock()):
-            spy_device_info = mocker.spy(mock_device, "_get_device_info")
-            spy_plcnet_info = mocker.spy(mock_device, "_get_plcnet_info")
-            await mock_device._gather_apis()
-            assert spy_device_info.call_count == 1
-            assert spy_plcnet_info.call_count == 1
-
-    @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_device_api")
     async def test__get_device_info(self, mock_device):
         with patch("devolo_plc_api.device.Device._get_zeroconf_info", new=AsyncMock()):
@@ -74,6 +64,16 @@ class TestDevice:
         await mock_device._get_zeroconf_info("_dvl-plcnetapi._tcp.local.")
         assert spy_cancel.call_count == 1
         assert spy_sleep.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test__setup_device(self, mocker, mock_device):
+        with patch("devolo_plc_api.device.Device._get_device_info", new=AsyncMock()), \
+             patch("devolo_plc_api.device.Device._get_plcnet_info", new=AsyncMock()):
+            spy_device_info = mocker.spy(mock_device, "_get_device_info")
+            spy_plcnet_info = mocker.spy(mock_device, "_get_plcnet_info")
+            await mock_device._setup_device()
+            assert spy_device_info.call_count == 1
+            assert spy_plcnet_info.call_count == 1
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_zeroconf")

--- a/tests/test_deviceapi.py
+++ b/tests/test_deviceapi.py
@@ -19,177 +19,176 @@ from devolo_plc_api.device_api.devolo_idl_proto_deviceapi_updatefirmware_pb2 imp
 class TestDeviceApi:
 
     @pytest.mark.parametrize("feature", ["[]"])
-    def test_unsupported_feature(self, device_api_sync):
+    def test_unsupported_feature(self, device_api):
         with pytest.raises(FeatureNotSupported):
-            device_api_sync.get_led_setting()
+            device_api.get_led_setting()
 
     @pytest.mark.parametrize("feature", [""])
-    def test_feature(self, device_api_sync):
-        assert device_api_sync.features == ['reset', 'update', 'led', 'intmtg']
+    def test_feature(self, device_api):
+        assert device_api.features == ['reset', 'update', 'led', 'intmtg']
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["led"])
-    async def test_async_get_led_setting(self, device_api_async):
+    async def test_async_get_led_setting(self, device_api):
         led_setting_get = LedSettingsGet()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=led_setting_get.SerializeToString())):
-            led_setting = await device_api_async.async_get_led_setting()
+            led_setting = await device_api.async_get_led_setting()
             assert led_setting == MessageToDict(led_setting_get,
                                                 including_default_value_fields=True,
                                                 preserving_proto_field_name=True)
 
     @pytest.mark.parametrize("feature", ["led"])
-    def test_get_led_setting(self, device_api_sync):
+    def test_get_led_setting(self, device_api):
         led_setting_get = LedSettingsGet()
-        with patch("httpx.Response.read", return_value=led_setting_get.SerializeToString()):
-            led_setting = device_api_sync.get_led_setting()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=led_setting_get.SerializeToString())):
+            led_setting = device_api.get_led_setting()
             assert led_setting == MessageToDict(led_setting_get,
                                                 including_default_value_fields=True,
                                                 preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["led"])
-    async def test_async_set_led_setting(self, device_api_async):
+    async def test_async_set_led_setting(self, device_api):
         led_setting_set = LedSettingsSetResponse()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=led_setting_set.SerializeToString())):
-            assert await device_api_async.async_set_led_setting(True)
+            assert await device_api.async_set_led_setting(True)
 
     @pytest.mark.parametrize("feature", ["led"])
-    def test_set_led_setting(self, device_api_sync):
+    def test_set_led_setting(self, device_api):
         led_setting_set = LedSettingsSetResponse()
-        with patch("httpx.Response.read", return_value=led_setting_set.SerializeToString()):
-            assert device_api_sync.set_led_setting(True)
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=led_setting_set.SerializeToString())):
+            assert device_api.set_led_setting(True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["update"])
-    async def test_async_check_firmware_available(self, device_api_async):
+    async def test_async_check_firmware_available(self, device_api):
         firmware_available = UpdateFirmwareCheck()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=firmware_available.SerializeToString())):
-            firmware = await device_api_async.async_check_firmware_available()
+            firmware = await device_api.async_check_firmware_available()
             assert firmware == MessageToDict(firmware_available,
                                              including_default_value_fields=True,
                                              preserving_proto_field_name=True)
 
     @pytest.mark.parametrize("feature", ["update"])
-    def test_check_firmware_available(self, device_api_sync):
+    def test_check_firmware_available(self, device_api):
         firmware_available = UpdateFirmwareCheck()
-        with patch("httpx.Response.read", return_value=firmware_available.SerializeToString()):
-            firmware = device_api_sync.check_firmware_available()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=firmware_available.SerializeToString())):
+            firmware = device_api.check_firmware_available()
             assert firmware == MessageToDict(firmware_available,
                                              including_default_value_fields=True,
                                              preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["update"])
-    async def test_async_start_firmware_update(self, device_api_async):
+    async def test_async_start_firmware_update(self, device_api):
         firmware_update = UpdateFirmwareStart()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=firmware_update.SerializeToString())):
-            assert await device_api_async.async_start_firmware_update()
+            assert await device_api.async_start_firmware_update()
 
     @pytest.mark.parametrize("feature", ["update"])
-    def test_start_firmware_update(self, device_api_sync):
+    def test_start_firmware_update(self, device_api):
         firmware_update = UpdateFirmwareStart()
-        with patch("httpx.Response.read", return_value=firmware_update.SerializeToString()):
-            assert device_api_sync.start_firmware_update()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=firmware_update.SerializeToString())):
+            assert device_api.start_firmware_update()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["wifi1"])
-    async def test_async_get_wifi_connected_station(self, device_api_async):
+    async def test_async_get_wifi_connected_station(self, device_api):
         wifi_connected_stations_get = WifiConnectedStationsGet()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_connected_stations_get.SerializeToString())):
-            connected_stations = await device_api_async.async_get_wifi_connected_station()
+            connected_stations = await device_api.async_get_wifi_connected_station()
             assert connected_stations == MessageToDict(wifi_connected_stations_get,
                                                        including_default_value_fields=True,
                                                        preserving_proto_field_name=True)
 
     @pytest.mark.parametrize("feature", ["wifi1"])
-    def test_get_wifi_connected_station(self, device_api_sync):
+    def test_get_wifi_connected_station(self, device_api):
         wifi_connected_stations_get = WifiConnectedStationsGet()
-        with patch("httpx.Response.read", return_value=wifi_connected_stations_get.SerializeToString()):
-            connected_stations = device_api_sync.get_wifi_connected_station()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_connected_stations_get.SerializeToString())):
+            connected_stations = device_api.get_wifi_connected_station()
             assert connected_stations == MessageToDict(wifi_connected_stations_get,
                                                        including_default_value_fields=True,
                                                        preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["wifi1"])
-    async def test_async_get_wifi_guest_access(self, device_api_async):
+    async def test_async_get_wifi_guest_access(self, device_api):
         wifi_guest_access_get = WifiGuestAccessGet()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_guest_access_get.SerializeToString())):
-            wifi_guest_access = await device_api_async.async_get_wifi_guest_access()
+            wifi_guest_access = await device_api.async_get_wifi_guest_access()
             assert wifi_guest_access == MessageToDict(wifi_guest_access_get,
                                                       including_default_value_fields=True,
                                                       preserving_proto_field_name=True)
 
     @pytest.mark.parametrize("feature", ["wifi1"])
-    def test_get_wifi_guest_access(self, device_api_sync):
+    def test_get_wifi_guest_access(self, device_api):
         wifi_guest_access_get = WifiGuestAccessGet()
-        with patch("httpx.Response.read", return_value=wifi_guest_access_get.SerializeToString()):
-            wifi_guest_access = device_api_sync.get_wifi_guest_access()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_guest_access_get.SerializeToString())):
+            wifi_guest_access = device_api.get_wifi_guest_access()
             assert wifi_guest_access == MessageToDict(wifi_guest_access_get,
                                                       including_default_value_fields=True,
                                                       preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["wifi1"])
-    async def test_async_set_wifi_guest_access(self, device_api_async):
+    async def test_async_set_wifi_guest_access(self, device_api):
         wifi_guest_access_set = WifiGuestAccessSetResponse()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_guest_access_set.SerializeToString())):
-            assert await device_api_async.async_set_wifi_guest_access(True)
+            assert await device_api.async_set_wifi_guest_access(True)
 
     @pytest.mark.parametrize("feature", ["wifi1"])
-    def test_set_wifi_guest_access(self, device_api_sync):
+    def test_set_wifi_guest_access(self, device_api):
         wifi_guest_access_set = WifiGuestAccessSetResponse()
-        with patch("httpx.Response.read", return_value=wifi_guest_access_set.SerializeToString()):
-            assert device_api_sync.set_wifi_guest_access(True)
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_guest_access_set.SerializeToString())):
+            assert device_api.set_wifi_guest_access(True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["wifi1"])
-    async def test_async_get_wifi_neighbor_access_points(self, device_api_async):
+    async def test_async_get_wifi_neighbor_access_points(self, device_api):
         wifi_neighbor_accesspoints_get = WifiNeighborAPsGet()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_neighbor_accesspoints_get.SerializeToString())):
-            wifi_neighbor_access_points = await device_api_async.async_get_wifi_neighbor_access_points()
+            wifi_neighbor_access_points = await device_api.async_get_wifi_neighbor_access_points()
             assert wifi_neighbor_access_points == MessageToDict(wifi_neighbor_accesspoints_get,
                                                                 including_default_value_fields=True,
                                                                 preserving_proto_field_name=True)
 
     @pytest.mark.parametrize("feature", ["wifi1"])
-    def test_get_wifi_neighbor_access_points(self, device_api_sync):
-        wifi_neighbor_access_points_get = WifiNeighborAPsGet()
-
-        with patch("httpx.Response.read", return_value=wifi_neighbor_access_points_get.SerializeToString()):
-            wifi_neighbor_access_points = device_api_sync.get_wifi_neighbor_access_points()
-            assert wifi_neighbor_access_points == MessageToDict(wifi_neighbor_access_points_get,
+    def test_get_wifi_neighbor_access_points(self, device_api):
+        wifi_neighbor_accesspoints_get = WifiNeighborAPsGet()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_neighbor_accesspoints_get.SerializeToString())):
+            wifi_neighbor_access_points = device_api.get_wifi_neighbor_access_points()
+            assert wifi_neighbor_access_points == MessageToDict(wifi_neighbor_accesspoints_get,
                                                                 including_default_value_fields=True,
                                                                 preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["wifi1"])
-    async def test_async_get_wifi_repeated_access_points(self, device_api_async):
+    async def test_async_get_wifi_repeated_access_points(self, device_api):
         wifi_repeated_accesspoints_get = WifiRepeatedAPsGet()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_repeated_accesspoints_get.SerializeToString())):
-            wifi_repeated_access_points = await device_api_async.async_get_wifi_repeated_access_points()
+            wifi_repeated_access_points = await device_api.async_get_wifi_repeated_access_points()
             assert wifi_repeated_access_points == MessageToDict(wifi_repeated_accesspoints_get,
                                                                 including_default_value_fields=True,
                                                                 preserving_proto_field_name=True)
 
     @pytest.mark.parametrize("feature", ["wifi1"])
-    def test_get_wifi_repeated_access_points(self, device_api_sync):
-        wifi_repeated_access_points_get = WifiRepeatedAPsGet()
-        with patch("httpx.Response.read", return_value=wifi_repeated_access_points_get.SerializeToString()):
-            wifi_repeated_access_points = device_api_sync.get_wifi_repeated_access_points()
-            assert wifi_repeated_access_points == MessageToDict(wifi_repeated_access_points_get,
+    def test_get_wifi_repeated_access_points(self, device_api):
+        wifi_repeated_accesspoints_get = WifiRepeatedAPsGet()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=wifi_repeated_accesspoints_get.SerializeToString())):
+            wifi_repeated_access_points = device_api.get_wifi_repeated_access_points()
+            assert wifi_repeated_access_points == MessageToDict(wifi_repeated_accesspoints_get,
                                                                 including_default_value_fields=True,
                                                                 preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", ["wifi1"])
-    async def test_async_start_wps(self, device_api_async):
+    async def test_async_start_wps(self, device_api):
         wps = WifiWpsPbcStart()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=wps.SerializeToString())):
-            assert await device_api_async.async_start_wps()
+            assert await device_api.async_start_wps()
 
     @pytest.mark.parametrize("feature", ["wifi1"])
-    def test_start_wps(self, device_api_sync):
+    def test_start_wps(self, device_api):
         wps = WifiWpsPbcStart()
-        with patch("httpx.Response.read", return_value=wps.SerializeToString()):
-            assert device_api_sync.start_wps()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=wps.SerializeToString())):
+            assert device_api.start_wps()

--- a/tests/test_plcnetapi.py
+++ b/tests/test_plcnetapi.py
@@ -16,52 +16,52 @@ from devolo_plc_api.plcnet_api.devolo_idl_proto_plcnetapi_setuserdevicename_pb2 
 class TestDeviceApi:
 
     @pytest.mark.asyncio
-    async def test_async_get_network_overview(self, plcnet_api_async):
+    async def test_async_get_network_overview(self, plcnet_api):
         network_overview = GetNetworkOverview()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=network_overview.SerializeToString())):
-            overview = await plcnet_api_async.async_get_network_overview()
+            overview = await plcnet_api.async_get_network_overview()
             assert overview == MessageToDict(network_overview,
                                              including_default_value_fields=True,
                                              preserving_proto_field_name=True)
 
-    def test_get_network_overview(self, plcnet_api_sync):
+    def test_get_network_overview(self, plcnet_api):
         network_overview = GetNetworkOverview()
-        with patch("httpx.Response.read", return_value=network_overview.SerializeToString()):
-            overview = plcnet_api_sync.get_network_overview()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=network_overview.SerializeToString())):
+            overview = plcnet_api.get_network_overview()
             assert overview == MessageToDict(network_overview,
                                              including_default_value_fields=True,
                                              preserving_proto_field_name=True)
 
     @pytest.mark.asyncio
-    async def test_async_identify_device_start(self, plcnet_api_async):
+    async def test_async_identify_device_start(self, plcnet_api):
         identify_device = IdentifyDeviceResponse()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=identify_device.SerializeToString())):
-            assert await plcnet_api_async.async_identify_device_start()
+            assert await plcnet_api.async_identify_device_start()
 
-    def test_identify_device_start(self, plcnet_api_sync):
+    def test_identify_device_start(self, plcnet_api):
         identify_device = IdentifyDeviceResponse()
-        with patch("httpx.Response.read", return_value=identify_device.SerializeToString()):
-            assert plcnet_api_sync.identify_device_start()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=identify_device.SerializeToString())):
+            assert plcnet_api.identify_device_start()
 
     @pytest.mark.asyncio
-    async def test_async_identify_device_stop(self, plcnet_api_async):
+    async def test_async_identify_device_stop(self, plcnet_api):
         identify_device = IdentifyDeviceResponse()
 
         with patch("httpx.Response.aread", new=AsyncMock(return_value=identify_device.SerializeToString())):
-            assert await plcnet_api_async.async_identify_device_stop()
+            assert await plcnet_api.async_identify_device_stop()
 
-    def test_identify_device_stop(self, plcnet_api_sync):
+    def test_identify_device_stop(self, plcnet_api):
         identify_device = IdentifyDeviceResponse()
-        with patch("httpx.Response.read", return_value=identify_device.SerializeToString()):
-            assert plcnet_api_sync.identify_device_stop()
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=identify_device.SerializeToString())):
+            assert plcnet_api.identify_device_stop()
 
     @pytest.mark.asyncio
-    async def test_async_set_user_device_name(self, plcnet_api_async):
+    async def test_async_set_user_device_name(self, plcnet_api):
         user_device_name_set = SetUserDeviceNameResponse()
         with patch("httpx.Response.aread", new=AsyncMock(return_value=user_device_name_set.SerializeToString())):
-            assert await plcnet_api_async.async_set_user_device_name("Test")
+            assert await plcnet_api.async_set_user_device_name("Test")
 
-    def test_set_user_device_name(self, plcnet_api_sync):
+    def test_set_user_device_name(self, plcnet_api):
         user_device_name_set = SetUserDeviceNameResponse()
-        with patch("httpx.Response.read", return_value=user_device_name_set.SerializeToString()):
-            assert plcnet_api_sync.set_user_device_name("Test")
+        with patch("httpx.Response.aread", new=AsyncMock(return_value=user_device_name_set.SerializeToString())):
+            assert plcnet_api.set_user_device_name("Test")

--- a/tests/test_profobuf.py
+++ b/tests/test_profobuf.py
@@ -7,6 +7,10 @@ from devolo_plc_api.exceptions.device import DevicePasswordProtected
 
 
 class TestProtobuf:
+    def test_attribute_error(self, mock_protobuf):
+        with pytest.raises(AttributeError):
+            mock_protobuf.test()
+
     def test_url(self, request, mock_protobuf):
         ip = request.cls.ip
         path = request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Path']
@@ -28,19 +32,6 @@ class TestProtobuf:
         with pytest.raises(DevicePasswordProtected):
             await mock_protobuf._async_get("LedSettingsGet")
 
-    @pytest.mark.usefixtures("mock_get")
-    def test__get(self, mocker, mock_protobuf):
-        mock_protobuf._session = httpx.Client()
-        spy = mocker.spy(httpx.Client, "get")
-        mock_protobuf._get("LedSettingsGet")
-        spy.assert_called_once()
-
-    @pytest.mark.usefixtures("mock_wrong_password")
-    def test__get_wrong_password(self, mock_protobuf):
-        mock_protobuf._session = httpx.Client()
-        with pytest.raises(DevicePasswordProtected):
-            mock_protobuf._get("LedSettingsGet")
-
     def test__message_to_dict(self, mocker, mock_protobuf):
         spy = mocker.spy(google.protobuf.json_format._Printer, "_MessageToJsonObject")
         mock_protobuf._message_to_dict(LedSettingsSetResponse())
@@ -60,16 +51,3 @@ class TestProtobuf:
         mock_protobuf._session = httpx.AsyncClient()
         with pytest.raises(DevicePasswordProtected):
             await mock_protobuf._async_post("LedSettingsGet", "")
-
-    @pytest.mark.usefixtures("mock_post")
-    def test__post(self, mocker, mock_protobuf):
-        mock_protobuf._session = httpx.Client()
-        spy = mocker.spy(httpx.Client, "post")
-        mock_protobuf._post("LedSettingsGet", "")
-        spy.assert_called_once()
-
-    @pytest.mark.usefixtures("mock_wrong_password")
-    def test__post_wrong_password(self, mock_protobuf):
-        mock_protobuf._session = httpx.Client()
-        with pytest.raises(DevicePasswordProtected):
-            mock_protobuf._post("LedSettingsGet", "")


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Remove code duplication by removing sync methods.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply. 
-->

- [ ] Version number in \_\_init\_\_.py was properly set.
- [ ] Changelog is updated.
