### PR TITLE
Combine parameters of APIs init

### DIFF
--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 
 from httpx import AsyncClient
 
@@ -14,31 +14,25 @@ class DeviceApi(Protobuf):
     Implementation of the devolo device API.
 
     :param ip: IP address of the device to communicate with
-    :param port: Port to communicate with
     :param session: HTTP client session
-    :param path: Path to send queries to
-    :param version: Version of the API to use
-    :param features: Feature, the device has
     :param password: Password of the device
     """
 
     def __init__(self,
                  ip: str,
-                 port: int,
                  session: AsyncClient,
-                 path: str,
-                 version: str,
-                 features: str,
+                 info: Dict,
                  password: Optional[str]):
         super().__init__()
         self._ip = ip
-        self._port = port
+        self._port = info['Port']
         self._session = session
-        self._path = path
-        self._version = version
+        self._path = info['Path']
+        self._version = info['Version']
         self._user = "devolo"
         self._password = password or ""
 
+        features = info.get("Features", "")
         self.features = features.split(",") if features else ['reset', 'update', 'led', 'intmtg']
 
     def _feature(feature: str):  # type: ignore  # pylint: disable=no-self-argument

--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -15,6 +15,7 @@ class DeviceApi(Protobuf):
 
     :param ip: IP address of the device to communicate with
     :param session: HTTP client session
+    :param info: Information collected from the mDNS query
     :param password: Password of the device
     """
 

--- a/devolo_plc_api/plcnet_api/plcnetapi.py
+++ b/devolo_plc_api/plcnet_api/plcnetapi.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from httpx import AsyncClient
 
 from ..clients.protobuf import Protobuf
@@ -11,27 +13,21 @@ class PlcNetApi(Protobuf):
     Implementation of the devolo plcnet API.
 
     :param ip: IP address of the device to communicate with
-    :param port: Port to communicate with
     :param session: HTTP client session
-    :param path: Path to send queries to
-    :param version: Version of the API to use
-    :param mac: Mac address of the to communicate with
+    :param info: Information collected from the mDNS query
     """
 
     def __init__(self,
                  ip: str,
-                 port: int,
                  session: AsyncClient,
-                 path: str,
-                 version: str,
-                 mac: str):
+                 info: Dict):
         super().__init__()
         self._ip = ip
-        self._port = port
+        self._mac = info['PlcMacAddress']
+        self._path = info['Path']
+        self._port = info['Port']
         self._session = session
-        self._path = path
-        self._version = version
-        self._mac = mac
+        self._version = info['Version']
         self._user = ""  # PLC API is not password protected.
         self._password = ""  # PLC API is not password protected.
 

--- a/tests/fixtures/device_api.py
+++ b/tests/fixtures/device_api.py
@@ -17,12 +17,10 @@ def device_api(request, feature):
          patch("devolo_plc_api.clients.protobuf.Protobuf._async_post", new=AsyncMock(return_value=Response)), \
          patch("asyncio.get_running_loop", asyncio.new_event_loop):
         asyncio.new_event_loop()
+        request.cls.device_info["_dvl-deviceapi._tcp.local."]["Features"] = feature
         yield DeviceApi(request.cls.ip,
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Port'],
                         AsyncClient(),
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Path'],
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Version'],
-                        feature,
+                        request.cls.device_info["_dvl-deviceapi._tcp.local."],
                         "password")
 
 

--- a/tests/fixtures/plcnet_api.py
+++ b/tests/fixtures/plcnet_api.py
@@ -18,11 +18,8 @@ def plcnet_api(request):
          patch("asyncio.get_running_loop", asyncio.new_event_loop):
         asyncio.new_event_loop()
         yield PlcNetApi(request.cls.ip,
-                        request.cls.device_info['_dvl-deviceapi._tcp.local.']['Port'],
                         AsyncClient(),
-                        request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Path'],
-                        request.cls.device_info['_dvl-plcnetapi._tcp.local.']['Version'],
-                        request.cls.device_info['_dvl-plcnetapi._tcp.local.']['PlcMacAddress'])
+                        request.cls.device_info["_dvl-plcnetapi._tcp.local."])
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Both API objects had a larger number of parameters that could easily be combined to a dictionary.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply. 
-->

- [ ] Version number in \_\_init\_\_.py was properly set.
- [ ] Changelog is updated.
