### PR TITLE
Add hostname and remove auto-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ If you don't know the IP addresses of your devices, you can discover them. You w
 from devolo_plc_api.network import async_discover_network
 
 devices = await async_discover_network()
+await asyncio.gather(*[device.async_connect() for device in _devices.values()])
 # Do your magic
 await asyncio.gather(*[device.async_disconnect() for device in devices.values()])
 ```
@@ -79,6 +80,8 @@ Or in a synchronous setup:
 from devolo_plc_api.network import discover_network
 
 devices = discover_network()
+for device in _devices.values():
+        device.connect()
 # Do your magic
 [device.disconnect() for device in devices.values()]
 ```

--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -34,6 +34,7 @@ class Device:
                  zeroconf_instance: Optional[Zeroconf] = None):
         self.firmware_date = date.fromtimestamp(0)
         self.firmware_version = ""
+        self.hostname = ""
         self.ip = ip
         self.mac = ""
         self.mt_number = 0
@@ -122,9 +123,10 @@ class Device:
 
         self.firmware_date = date.fromisoformat(self._info[service_type]["properties"].get("FirmwareDate", "1970-01-01"))
         self.firmware_version = self._info[service_type]["properties"].get("FirmwareVersion", "")
-        self.serial_number = self._info[service_type]["properties"].get("SN", 0)
+        self.hostname = self._info[service_type].get("hostname", "")
         self.mt_number = self._info[service_type]["properties"].get("MT", 0)
         self.product = self._info[service_type]["properties"].get("Product", "")
+        self.serial_number = self._info[service_type]["properties"]["SN"]
 
         self.device = DeviceApi(ip=self.ip, session=self._session, info=self._info[service_type])
 
@@ -182,6 +184,7 @@ class Device:
 
         return {
             "address": str(ipaddress.ip_address(address)),
+            "hostname": service_info.server,
             "port": service_info.port,
             "properties": properties,
         }

--- a/devolo_plc_api/network/__init__.py
+++ b/devolo_plc_api/network/__init__.py
@@ -19,7 +19,6 @@ async def async_discover_network() -> Dict[str, Device]:
     browser = ServiceBrowser(Zeroconf(), "_dvl-deviceapi._tcp.local.", [_add])
     await asyncio.sleep(3)
     browser.cancel()
-    await asyncio.gather(*[device.async_connect() for device in _devices.values()])
     return _devices
 
 
@@ -32,8 +31,6 @@ def discover_network() -> Dict[str, Device]:
     browser = ServiceBrowser(Zeroconf(), "_dvl-deviceapi._tcp.local.", [_add])
     time.sleep(3)
     browser.cancel()
-    for device in _devices.values():
-        device.connect()
     return _devices
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- mDNS hostname is now stored in the device object
+
+### Changed
+
+** BREAKING**: The discovery function does no longer connect to the device automatically
+
 ## [v0.3.0] - 02.12.2020
 
 ### Added

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -23,9 +23,7 @@ class TestNetwork:
              patch("asyncio.sleep", new=AsyncMock()), \
              patch("devolo_plc_api.device.Device.async_connect", new=AsyncMock()):
             network._devices = device
-            spy_connect = mocker.spy(Device, "async_connect")
             discovered = await network.async_discover_network()
-            assert spy_connect.call_count == 1
             assert discovered == device
 
     def test_discover_network(self, mocker):
@@ -36,9 +34,7 @@ class TestNetwork:
              patch("time.sleep", new=Mock()), \
              patch("devolo_plc_api.device.Device.connect", new=Mock()):
             network._devices = device
-            spy_connect = mocker.spy(Device, "connect")
             discovered = network.discover_network()
-            assert spy_connect.call_count == 1
             assert discovered == device
 
     def test__add(self, mocker):


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Add hostname to den Device object and do not auto-connect to devices when discovered to enable talking to dedicated devices only.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Version number in \_\_init\_\_.py was properly set.
- [ ] Changelog is updated.
