### PR TITLE
Increase read timeout

### DIFF
--- a/devolo_plc_api/clients/protobuf.py
+++ b/devolo_plc_api/clients/protobuf.py
@@ -8,7 +8,7 @@ from httpx import AsyncClient, DigestAuth, Response
 
 from ..exceptions.device import DevicePasswordProtected
 
-TIMEOUT = 3.0
+TIMEOUT = 5.0
 
 
 class Protobuf(ABC):

--- a/devolo_plc_api/network/__init__.py
+++ b/devolo_plc_api/network/__init__.py
@@ -36,13 +36,15 @@ def discover_network() -> Dict[str, Device]:
 
 def _add(zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange):
     """" Create a device object to each matching device. """
-    if state_change is ServiceStateChange.Added:
-        service_info = zeroconf.get_service_info(service_type, name)
-        if service_info is None:
-            return
+    if state_change is not ServiceStateChange.Added:
+        return
 
-        info = Device.info_from_service(service_info)
-        if info is None or info["properties"]["MT"] in ("2600", "2601"):
-            return  # Don't react on devolo Home Control central units
+    service_info = zeroconf.get_service_info(service_type, name)
+    if service_info is None:
+        return
 
-        _devices[info["properties"]["SN"]] = Device(ip=info["address"], deviceapi=info, zeroconf_instance=zeroconf)
+    info = Device.info_from_service(service_info)
+    if info is None or info["properties"]["MT"] in ("2600", "2601"):
+        return  # Don't react on devolo Home Control central units
+
+    _devices[info["properties"]["SN"]] = Device(ip=info["address"], deviceapi=info, zeroconf_instance=zeroconf)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+-
+### Changed
+
+- Increase read timeout to better handle busy devices
+
 ## [v0.4.0] - 2020/12/08
 
 ### Added

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -50,6 +50,13 @@ class TestNetwork:
             network._add(Zeroconf(), "_dvl-deviceapi._tcp.local.", "_dvl-deviceapi._tcp.local.", ServiceStateChange.Added)
             assert "1234567890123456" in network._devices
 
+    def test__add_wrong_state(self, mocker):
+        with patch("zeroconf.Zeroconf.get_service_info", return_value="service_info"), \
+             patch("devolo_plc_api.device.Device.info_from_service", return_value=None):
+            spy_device = mocker.spy(Device, "__init__")
+            network._add(Zeroconf(), "_dvl-deviceapi._tcp.local.", "_dvl-deviceapi._tcp.local.", ServiceStateChange.Removed)
+            assert spy_device.call_count == 0
+
     def test__add_no_device(self, mocker):
         with patch("zeroconf.Zeroconf.get_service_info", return_value=None):
             spy_info = mocker.spy(Device, "info_from_service")


### PR DESCRIPTION
## Proposed change
Sometimes (especially with concurrent requests) the device is to busy to answer in time. We should increase the read timeout a bit to reduce situations where this happens.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Version number in \_\_init\_\_.py was properly set.
- [ ] Changelog is updated.
