### PR TITLE
Allow Zeroconf instances to be passed in

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -38,7 +38,7 @@ class Device:
                                  Any] | None = None,
                  deviceapi: dict[str,
                                  Any] | None = None,
-                 zeroconf_instance: AsyncZeroconf | None = None) -> None:
+                 zeroconf_instance: AsyncZeroconf | Zeroconf | None = None) -> None:
         self.firmware_date = date.fromtimestamp(0)
         self.firmware_version = ""
         self.hostname = ""
@@ -108,7 +108,12 @@ class Device:
         self._loop = asyncio.get_running_loop()
         self._session_instance = session_instance
         self._session = self._session_instance or httpx.AsyncClient()
-        self._zeroconf = self._zeroconf_instance or AsyncZeroconf()
+        if not self._zeroconf_instance:
+            self._zeroconf = AsyncZeroconf()
+        elif isinstance(self._zeroconf_instance, Zeroconf):
+            self._zeroconf = AsyncZeroconf(zc=self._zeroconf_instance)
+        else:
+            self._zeroconf = self._zeroconf_instance
         await asyncio.gather(self._get_device_info(), self._get_plcnet_info())
         if not self.device and not self.plcnet:
             raise DeviceNotFound(f"The device {self.ip} did not answer.")

--- a/devolo_plc_api/network/__init__.py
+++ b/devolo_plc_api/network/__init__.py
@@ -47,4 +47,4 @@ def _add(zeroconf: Zeroconf, service_type: str, name: str, state_change: Service
     if info is None or info["properties"]["MT"] in ("2600", "2601"):
         return  # Don't react on devolo Home Control central units
 
-    _devices[info["properties"]["SN"]] = Device(ip=info["address"], deviceapi=info)
+    _devices[info["properties"]["SN"]] = Device(ip=info["address"], deviceapi=info, zeroconf_instance=zeroconf)


### PR DESCRIPTION
## Proposed change

<!--
  Please give us the big picture of your change.
-->
Formerly, also Zeroconf instances could be passed to Device. This MR restores that capability by passing that Zeroconf instance to AsyncZeroconf.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
