### PR TITLE
Fix sync disconnect

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -134,7 +134,7 @@ class Device:
 
     def disconnect(self) -> None:
         """ Disconnect from a device asynchronous. """
-        self._loop.run_until_complete(self.async_disconnect())
+        asyncio.gather(self.async_disconnect())
         self._loop.close()
 
     async def _get_device_info(self) -> None:

--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -133,7 +133,7 @@ class Device:
         self._connected = False
 
     def disconnect(self) -> None:
-        """ Disconnect from a device asynchronous. """
+        """ Disconnect from a device synchronous. """
         asyncio.gather(self.async_disconnect())
         self._loop.close()
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [v0.6.3] - 2021/11/18
+
+### Fixed
+
+- Disconncting from a device synchroniously works again
+
 ### [v0.6.2] - 2021/10/28
 
 ### Fixed


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
When disconnecting from a device to quickly using the sync way, you could run into a RuntimeError.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
