### PR TITLE
Fix async_get_led_setting

### DIFF
--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -52,7 +52,7 @@ class DeviceApi(Protobuf):
         return feature_decorator
 
     @_feature("led")
-    async def async_get_led_setting(self) -> dict[str, Any]:
+    async def async_get_led_setting(self) -> dict[str, str]:
         """
         Get LED setting asynchronously. This feature only works on devices, that announce the led feature.
 
@@ -61,7 +61,7 @@ class DeviceApi(Protobuf):
         self._logger.debug("Getting LED settings.")
         led_setting = devolo_idl_proto_deviceapi_ledsettings_pb2.LedSettingsGet()
         response = await self._async_get("LedSettingsGet")
-        led_setting.FromString(await response.aread())  # pylint: disable=no-member
+        led_setting.ParseFromString(await response.aread())  # pylint: disable=no-member
         return self._message_to_dict(led_setting)
 
     @_feature("led")
@@ -108,7 +108,7 @@ class DeviceApi(Protobuf):
         return int(self._message_to_dict(uptime)["uptime"])
 
     @_feature("update")
-    async def async_check_firmware_available(self) -> dict[str, Any]:
+    async def async_check_firmware_available(self) -> dict[str, str]:
         """
         Check asynchronously, if a firmware update is available for the device.
 
@@ -135,7 +135,7 @@ class DeviceApi(Protobuf):
         return bool(not update_firmware.result)  # pylint: disable=no-member
 
     @_feature("wifi1")
-    async def async_get_wifi_connected_station(self) -> dict[str, Any]:
+    async def async_get_wifi_connected_station(self) -> dict[str, list]:
         """
         Get wifi stations connected to the device asynchronously. This feature only works on devices, that announce the wifi1
         feature.
@@ -149,7 +149,7 @@ class DeviceApi(Protobuf):
         return self._message_to_dict(wifi_connected_proto)
 
     @_feature("wifi1")
-    async def async_get_wifi_guest_access(self) -> dict[str, Any]:
+    async def async_get_wifi_guest_access(self) -> dict[str, bool | int | str]:
         """
         Get details about wifi guest access asynchronously. This feature only works on devices, that announce the wifi1
         feature.
@@ -179,7 +179,7 @@ class DeviceApi(Protobuf):
         return bool(not response.result)  # pylint: disable=no-member
 
     @_feature("wifi1")
-    async def async_get_wifi_neighbor_access_points(self) -> dict[str, Any]:
+    async def async_get_wifi_neighbor_access_points(self) -> dict[str, list]:
         """
         Get wifi access point in the neighborhood asynchronously. This feature only works on devices, that announce the wifi1
         feature.
@@ -193,7 +193,7 @@ class DeviceApi(Protobuf):
         return self._message_to_dict(wifi_neighbor_aps)
 
     @_feature("wifi1")
-    async def async_get_wifi_repeated_access_points(self) -> dict[str, Any]:
+    async def async_get_wifi_repeated_access_points(self) -> dict[str, list]:
         """
         Get repeated wifi access point asynchronously. This feature only works on repeater devices, that announce the wifi1
         feature.

--- a/devolo_plc_api/plcnet_api/plcnetapi.py
+++ b/devolo_plc_api/plcnet_api/plcnetapi.py
@@ -32,7 +32,7 @@ class PlcNetApi(Protobuf):
 
         self.password = ""  # PLC API is not password protected.
 
-    async def async_get_network_overview(self) -> dict[str, Any]:
+    async def async_get_network_overview(self) -> dict[str, dict]:
         """
         Get a PLC network overview.
 
@@ -46,7 +46,7 @@ class PlcNetApi(Protobuf):
 
     async def async_identify_device_start(self) -> bool:
         """
-        Make PLC LED of a device blick to identify it.
+        Make PLC LED of a device blink to identify it.
 
         :return: True, if identifying was successfully started, otherwise False
         """
@@ -60,7 +60,7 @@ class PlcNetApi(Protobuf):
 
     async def async_identify_device_stop(self) -> bool:
         """
-        Stop the PLC LED blicking.
+        Stop the PLC LED blinking.
 
         :return: True, if identifying was successfully stopped, otherwise False
         """
@@ -72,7 +72,7 @@ class PlcNetApi(Protobuf):
         response.FromString(await query.aread())  # pylint: disable=no-member
         return bool(not response.result)  # pylint: disable=no-member
 
-    async def async_set_user_device_name(self, name) -> bool:
+    async def async_set_user_device_name(self, name: str) -> bool:
         """
         Set device name.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [v0.7.0] - 2021/11/30
+## [v0.7.1] - 2022/01/10
+
+### Fixed
+
+- Get LED status from devices
+
+## [v0.7.0] - 2021/11/30
 
 ### Added
 


### PR DESCRIPTION
## Proposed change

<!--
  Please give us the big picture of your change.
-->
async_get_led_setting was broken. This fixes reading the protobuf message and also makes typing a bit more strict.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
