### PR TITLE
Discovery devices as unicast first

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -155,9 +155,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
         if self.mt_number in DEVICES_WITHOUT_PLCNET:
             return
         await self._get_zeroconf_info(service_type=service_type)
-        if not self._info[service_type]["properties"]:
-            if self.mt_number in DEVICES_WITHOUT_PLCNET:
-                return
+        if not self._info[service_type]["properties"] and self.mt_number not in DEVICES_WITHOUT_PLCNET:
             await self._retry_zeroconf_info(service_type=service_type)
         if self._info[service_type]["properties"]:
             self.mac = self._info[service_type]["properties"]["PlcMacAddress"]

--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -33,7 +33,7 @@ def _feature(
         def wrapper(deviceapi: DeviceApi, *args: _P.args, **kwargs: _P.kwargs) -> _ReturnT:
             if feature in deviceapi.features:
                 return method(deviceapi, *args, **kwargs)
-            raise FeatureNotSupported(f"The device does not support {method}.")
+            raise FeatureNotSupported(f"The device does not support {method.__name__}.")
 
         return wrapper
 

--- a/devolo_plc_api/plcnet_api/__init__.py
+++ b/devolo_plc_api/plcnet_api/__init__.py
@@ -1,6 +1,7 @@
 """The devolo plcnet API."""
 from .plcnetapi import PlcNetApi
 
+DEVICES_WITHOUT_PLCNET = [3046, 3047, 3048, 3049, 3254, 3255]
 SERVICE_TYPE = "_dvl-plcnetapi._tcp.local."
 
 __all__ = ["PlcNetApi"]

--- a/tests/mocks/mock_zeroconf.py
+++ b/tests/mocks/mock_zeroconf.py
@@ -5,5 +5,5 @@ class MockServiceBrowser:
 
     async_cancel = AsyncMock()
 
-    def __init__(self, zc, st, sc, question_type=None) -> None:
-        sc[0]()
+    def __init__(self, zeroconf, type_, handlers, addr, question_type=None) -> None:
+        handlers[0]()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -77,6 +77,14 @@ class TestDevice:
             assert type(mock_device.device) == DeviceApi
 
     @pytest.mark.asyncio
+    async def test__get_device_info_multicast(self):
+        with patch("devolo_plc_api.device.Device._get_zeroconf_info") as gzi:
+            device = Device(self.ip)
+            await device._get_device_info()
+            assert device._multicast is True
+            assert gzi.call_count == 2
+
+    @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_plcnet_api")
     async def test__get_plcnet_info(self, mock_device: Device):
         with patch("devolo_plc_api.device.Device._get_zeroconf_info"):
@@ -85,6 +93,14 @@ class TestDevice:
             assert mock_device.mac == device_info["properties"]["PlcMacAddress"]
             assert mock_device.technology == device_info["properties"]["PlcTechnology"]
             assert type(mock_device.plcnet) == PlcNetApi
+
+    @pytest.mark.asyncio
+    async def test__get_plcnet_info_multicast(self):
+        with patch("devolo_plc_api.device.Device._get_zeroconf_info") as gzi:
+            device = Device(self.ip)
+            await device._get_plcnet_info()
+            assert device._multicast is True
+            assert gzi.call_count == 2
 
     @pytest.mark.asyncio
     async def test__get_zeroconf_info_timeout(self, mock_device: Device):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -9,6 +9,7 @@ from devolo_plc_api.device import EMPTY_INFO, Device
 from devolo_plc_api.device_api import SERVICE_TYPE as DEVICEAPI
 from devolo_plc_api.device_api import DeviceApi
 from devolo_plc_api.exceptions.device import DeviceNotFound
+from devolo_plc_api.plcnet_api import DEVICES_WITHOUT_PLCNET
 from devolo_plc_api.plcnet_api import SERVICE_TYPE as PLCNETAPI
 from devolo_plc_api.plcnet_api import PlcNetApi
 from tests.mocks.mock_zeroconf import MockServiceBrowser
@@ -93,6 +94,14 @@ class TestDevice:
             assert mock_device.mac == device_info["properties"]["PlcMacAddress"]
             assert mock_device.technology == device_info["properties"]["PlcTechnology"]
             assert type(mock_device.plcnet) == PlcNetApi
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_plcnet_api")
+    async def test__not_get_plcnet_info(self, mock_device: Device):
+        mock_device.mt_number = DEVICES_WITHOUT_PLCNET[0]
+        with patch("devolo_plc_api.device.Device._get_zeroconf_info"):
+            await mock_device._get_plcnet_info()
+            assert not mock_device.plcnet
 
     @pytest.mark.asyncio
     async def test__get_plcnet_info_multicast(self):


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Some devices can be setup properly using QU. This reduces the network traffic and the load on weak devices. However, some can't and for those a fallback to QM was added. Unfortunately, setting up devices that miss one of the APIs will take twice the mDNS timeout now.


## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
