### PR TITLE
Handle developer builds

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -141,7 +141,9 @@ class Device:  # pylint: disable=too-many-instance-attributes
         if not self._info[service_type]["properties"]:
             await self._retry_zeroconf_info(service_type=service_type)
         if self._info[service_type]["properties"]:
-            self.firmware_date = date.fromisoformat(self._info[service_type]["properties"].get("FirmwareDate", "1970-01-01"))
+            self.firmware_date = date.fromisoformat(
+                self._info[service_type]["properties"].get("FirmwareDate", "1970-01-01")[:10]
+            )
             self.firmware_version = self._info[service_type]["properties"].get("FirmwareVersion", "")
             self.hostname = self._info[service_type].get("hostname", "")
             self.mt_number = self._info[service_type]["properties"].get("MT", 0)


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Developer builds typically have a build time in their build date which makes date.fromisoformat fail. As this info is not interesting for us, I simply truncate the build date to 10 characters.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
