### PR TITLE
Use correct device password if password was set before connecting to it

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -150,6 +150,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
             self.product = self._info[service_type]["properties"].get("Product", "")
             self.serial_number = self._info[service_type]["properties"]["SN"]
             self.device = DeviceApi(ip=self.ip, session=self._session, info=self._info[service_type])
+            self.device.password = self.password
 
     async def _get_plcnet_info(self) -> None:
         """Get information from the devolo PlcNet API."""

--- a/devolo_plc_api/device_api/deviceapi.pyi
+++ b/devolo_plc_api/device_api/deviceapi.pyi
@@ -6,7 +6,6 @@ from __future__ import annotations
 from ..clients.protobuf import Protobuf
 from httpx import AsyncClient as AsyncClient
 from typing import Any
-from typing_extensions import Concatenate as Concatenate
 
 class DeviceApi(Protobuf):
     features: list[str]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.1] - 2022/10/18
+
+### Fixed
+
+- Use correct device password if password was set before connecting to it
+
 ## [v0.8.0] - 2022/05/06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ urls = {changelog = "https://github.com/2Fake/devolo_plc_api/docs/CHANGELOG.md",
 [project.optional-dependencies]
 dev = [
     "pre-commit",
+    "mypy>=0.981"
 ]
 test = [
     "pytest",

--- a/script/stubgen.py
+++ b/script/stubgen.py
@@ -89,18 +89,12 @@ def generate_stubs() -> None:
         target = os.path.join(options.output_dir, target)
         files.append(target)
         with generate_guarded(mod.module, target, options.ignore_errors, options.verbose):
-            generate_stub_from_ast(
-                mod, target, options.parse_only, options.pyversion, options.include_private, options.export_less
-            )
+            generate_stub_from_ast(mod, target, options.parse_only, options.include_private, options.export_less)
 
 
-def generate_stub_from_ast(
-    mod: StubSource, target: str, parse_only: bool, pyversion: tuple[int, int], include_private: bool, export_less: bool
-) -> None:
+def generate_stub_from_ast(mod: StubSource, target: str, parse_only: bool, include_private: bool, export_less: bool) -> None:
     """Use analysed (or just parsed) AST to generate type stub for single file."""
-    gen = ApiStubGenerator(
-        mod.runtime_all, pyversion=pyversion, include_private=include_private, analyzed=not parse_only, export_less=export_less
-    )
+    gen = ApiStubGenerator(mod.runtime_all, include_private=include_private, analyzed=not parse_only, export_less=export_less)
     mod.ast.accept(gen)
     if "annotations" in mod.ast.future_import_flags:
         gen.add_import_line("from __future__ import annotations\n")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -109,6 +109,7 @@ class TestDevice:
         """Test that information from the device API are filled in."""
         with patch("devolo_plc_api.device.Device._get_zeroconf_info"):
             device_info = test_data.device_info[DEVICEAPI]
+            mock_device.password = "super_secret"
             await mock_device.async_connect()
             assert mock_device.firmware_date == date.fromisoformat(device_info["properties"]["FirmwareDate"])
             assert mock_device.firmware_version == device_info["properties"]["FirmwareVersion"]
@@ -116,6 +117,7 @@ class TestDevice:
             assert mock_device.mt_number == device_info["properties"]["MT"]
             assert mock_device.product == device_info["properties"]["Product"]
             assert isinstance(mock_device.device, DeviceApi)
+            assert mock_device.device.password == mock_device.password
 
     @pytest.mark.asyncio
     async def test__get_device_info_multicast(self, test_data: TestData):


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
If you set a password in the Device object and then connect to the real device, the password is not used. Only connecting and then setting the password works. However, this might be unhandy, so this MR fixes that.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
