### PR TITLE
Remove setup.py

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --no-compile --no-binary=mypy mypy
+        python -m pip install --no-binary=mypy mypy
     - name: Check formatting
       uses: pre-commit/action@v3.0.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,22 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: '22.3.0'
+    rev: '22.12.0'
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.11.4'
     hooks:
         - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.1.0'
+    rev: 'v4.3.0'
     hooks:
+        - id: check-json
         - id: end-of-file-fixer
         - id: trailing-whitespace
+-   repo: https://github.com/abravalheri/validate-pyproject
+    rev: 'v0.10.1'
+    hooks:
+      - id: validate-pyproject
 -   repo: local
     hooks:
         - id: stubgen

--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -49,7 +49,6 @@ def _feature(
     return feature_decorator
 
 
-# Issue: https://github.com/PyCQA/pylint/issues/4987
 class DeviceApi(Protobuf):
     """
     Implementation of the devolo device API.

--- a/devolo_plc_api/plcnet_api/plcnetapi.py
+++ b/devolo_plc_api/plcnet_api/plcnetapi.py
@@ -11,7 +11,6 @@ from .pairdevice_pb2 import PairDeviceResponse, PairDeviceStart
 from .setuserdevicename_pb2 import SetUserDeviceName, SetUserDeviceNameResponse
 
 
-# Issue: https://github.com/PyCQA/pylint/issues/4987
 class PlcNetApi(Protobuf):
     """
     Implementation of the devolo plcnet API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=65", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""Required for editable installs."""
-from setuptools import setup
-
-# Issue: https://github.com/pypa/setuptools/pull/3265
-setup()


### PR DESCRIPTION
## Proposed change
As setuptools fixed editable installs using pyproject.toml, we can remove setup.py

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
