### PR TITLE
Support devices with password protected plcnet API

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -104,6 +104,8 @@ class Device:  # pylint: disable=too-many-instance-attributes
         self._password = password
         if self.device:
             self.device.password = password
+        if self.plcnet:
+            self.plcnet.password = password
 
     async def async_connect(self, session_instance: httpx.AsyncClient | None = None) -> None:
         """
@@ -168,6 +170,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
             self.mac = self._info[service_type].properties["PlcMacAddress"]
             self.technology = self._info[service_type].properties.get("PlcTechnology", "")
             self.plcnet = PlcNetApi(ip=self.ip, session=self._session, info=self._info[service_type])
+            self.plcnet.password = self.password
 
     async def _get_zeroconf_info(self, service_type: str) -> None:
         """Browse for the desired mDNS service types and query them."""

--- a/devolo_plc_api/exceptions/device.py
+++ b/devolo_plc_api/exceptions/device.py
@@ -10,4 +10,4 @@ class DeviceUnavailable(Exception):
 
 
 class DevicePasswordProtected(Exception):
-    """The device is passwort protected."""
+    """The device is password protected."""

--- a/devolo_plc_api/plcnet_api/plcnetapi.py
+++ b/devolo_plc_api/plcnet_api/plcnetapi.py
@@ -28,10 +28,10 @@ class PlcNetApi(Protobuf):
         self._path = info.properties["Path"]
         self._port = info.port
         self._session = session
-        self._user = ""  # PLC API is not password protected.
+        self._user = "devolo"
         self._version = info.properties["Version"]
 
-        self.password = ""  # PLC API is not password protected.
+        self.password = ""
 
     async def async_get_network_overview(self) -> GetNetworkOverview.LogicalNetwork:
         """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support for devices with password protected PLCNET API
+
 ## [v1.1.0] - 2023/01/24
 
 ### Added
@@ -38,7 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Start WPS clone mode
 - Factory reset device
 
-#### PLC API
+#### PLCNET API
 
 - Start pairing mode
 
@@ -154,7 +160,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Under unfavorable conditions incorrect PLC API data was collected
+- Under unfavorable conditions incorrect PLCNET API data was collected
 
 ## [v0.3.0] - 2020/12/02
 
@@ -199,7 +205,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Get visible wifi access points
 - Get details about master wifi (repeater only)
 
-#### PLC API
+#### PLCNET API
 
 - Get details about your powerline network
 - Start and stop identifying your PLC device

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -25,11 +25,13 @@ class TestDevice:
     """Test devolo_plc_api.device.Device class."""
 
     @pytest.mark.parametrize("feature", [""])
-    def test_set_password(self, mock_device: Device, device_api: DeviceApi):
+    def test_set_password(self, mock_device: Device, device_api: DeviceApi, plcnet_api: PlcNetApi):
         """Test setting a device password is also reflected in the device API."""
         mock_device.device = device_api
+        mock_device.plcnet = plcnet_api
         mock_device.password = "super_secret"
         assert mock_device.device.password == "super_secret"
+        assert mock_device.plcnet.password == "super_secret"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("feature", [""])


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Next firmware versions will protect some PLCNET API calls with the device password. This MR supports using the password using the fact, that old firmware version ignore a sent password.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
