### PR TITLE
Use isort combine-as-imports

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -13,12 +13,9 @@ import httpx
 from zeroconf import DNSQuestionType, ServiceInfo, ServiceStateChange, Zeroconf
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
-from .device_api import SERVICE_TYPE as DEVICEAPI
-from .device_api import DeviceApi
+from .device_api import SERVICE_TYPE as DEVICEAPI, DeviceApi
 from .exceptions.device import DeviceNotFound
-from .plcnet_api import DEVICES_WITHOUT_PLCNET
-from .plcnet_api import SERVICE_TYPE as PLCNETAPI
-from .plcnet_api import PlcNetApi
+from .plcnet_api import DEVICES_WITHOUT_PLCNET, SERVICE_TYPE as PLCNETAPI, PlcNetApi
 from .zeroconf import ZeroconfServiceInfo
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ line-length = 127
 force-exclude = '.*_pb2\.py|.*\.pyi'
 
 [tool.isort]
+combine_as_imports = true
 filter_files = true
 ignore_whitespace = true
 line_length = 127

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -6,12 +6,9 @@ import pytest
 from zeroconf import ServiceStateChange
 
 from devolo_plc_api.device import Device
-from devolo_plc_api.device_api import SERVICE_TYPE as DEVICEAPI
-from devolo_plc_api.device_api import DeviceApi
+from devolo_plc_api.device_api import SERVICE_TYPE as DEVICEAPI, DeviceApi
 from devolo_plc_api.exceptions.device import DeviceNotFound
-from devolo_plc_api.plcnet_api import DEVICES_WITHOUT_PLCNET
-from devolo_plc_api.plcnet_api import SERVICE_TYPE as PLCNETAPI
-from devolo_plc_api.plcnet_api import PlcNetApi
+from devolo_plc_api.plcnet_api import DEVICES_WITHOUT_PLCNET, SERVICE_TYPE as PLCNETAPI, PlcNetApi
 from devolo_plc_api.zeroconf import ZeroconfServiceInfo
 from tests.mocks.mock_zeroconf import MockServiceBrowser
 

--- a/tests/test_profobuf.py
+++ b/tests/test_profobuf.py
@@ -85,7 +85,7 @@ class TestProtobuf:
         await mock_device.async_connect()
         assert mock_device.device
         with pytest.raises(HTTPStatusError):
-            await mock_device.device.async_get_wifi_connected_station()
+            await mock_device.device.async_set_wifi_guest_access(True)
         await mock_device.async_disconnect()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
isort has several settings to change the way imports are sorted. This MR enables combine-as-imports to make imports a bit more compact.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
