### PR TITLE
Use absolute imports

### DIFF
--- a/devolo_plc_api/clients/protobuf.py
+++ b/devolo_plc_api/clients/protobuf.py
@@ -19,7 +19,7 @@ from httpx import (
     Response,
 )
 
-from ..exceptions.device import DevicePasswordProtected, DeviceUnavailable
+from devolo_plc_api.exceptions.device import DevicePasswordProtected, DeviceUnavailable
 
 TIMEOUT = 10.0
 

--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -6,9 +6,10 @@ from typing import TYPE_CHECKING, Callable, TypeVar
 
 from httpx import AsyncClient
 
-from ..clients import Protobuf
-from ..exceptions.feature import FeatureNotSupported
-from ..zeroconf import ZeroconfServiceInfo
+from devolo_plc_api.clients import Protobuf
+from devolo_plc_api.exceptions.feature import FeatureNotSupported
+from devolo_plc_api.zeroconf import ZeroconfServiceInfo
+
 from .factoryreset_pb2 import FactoryResetStart
 from .ledsettings_pb2 import LedSettingsGet, LedSettingsSet, LedSettingsSetResponse
 from .restart_pb2 import RestartResponse, UptimeGetResponse

--- a/devolo_plc_api/device_api/deviceapi.pyi
+++ b/devolo_plc_api/device_api/deviceapi.pyi
@@ -3,11 +3,11 @@
 isort:skip_file
 """
 from __future__ import annotations
-from ..clients import Protobuf
-from ..zeroconf import ZeroconfServiceInfo as ZeroconfServiceInfo
 from .support_pb2 import SupportInfoDump
 from .updatefirmware_pb2 import UpdateFirmwareCheck
 from .wifinetwork_pb2 import WifiConnectedStationsGet, WifiGuestAccessGet, WifiNeighborAPsGet, WifiRepeatedAPsGet
+from devolo_plc_api.clients import Protobuf
+from devolo_plc_api.zeroconf import ZeroconfServiceInfo as ZeroconfServiceInfo
 from httpx import AsyncClient as AsyncClient
 
 class DeviceApi(Protobuf):

--- a/devolo_plc_api/network/__init__.py
+++ b/devolo_plc_api/network/__init__.py
@@ -7,8 +7,8 @@ from ipaddress import ip_address
 
 from zeroconf import DNSQuestionType, ServiceBrowser, ServiceStateChange, Zeroconf
 
-from ..device import Device
-from ..device_api import SERVICE_TYPE
+from devolo_plc_api.device import Device
+from devolo_plc_api.device_api import SERVICE_TYPE
 
 
 async def async_discover_network() -> dict[str, Device]:

--- a/devolo_plc_api/plcnet_api/plcnetapi.py
+++ b/devolo_plc_api/plcnet_api/plcnetapi.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 from httpx import AsyncClient
 
-from ..clients import Protobuf
-from ..zeroconf import ZeroconfServiceInfo
+from devolo_plc_api.clients import Protobuf
+from devolo_plc_api.zeroconf import ZeroconfServiceInfo
+
 from .getnetworkoverview_pb2 import GetNetworkOverview
 from .identifydevice_pb2 import IdentifyDeviceResponse, IdentifyDeviceStart, IdentifyDeviceStop
 from .pairdevice_pb2 import PairDeviceResponse, PairDeviceStart

--- a/devolo_plc_api/plcnet_api/plcnetapi.pyi
+++ b/devolo_plc_api/plcnet_api/plcnetapi.pyi
@@ -3,9 +3,9 @@
 isort:skip_file
 """
 from __future__ import annotations
-from ..clients import Protobuf
-from ..zeroconf import ZeroconfServiceInfo as ZeroconfServiceInfo
 from .getnetworkoverview_pb2 import GetNetworkOverview
+from devolo_plc_api.clients import Protobuf
+from devolo_plc_api.zeroconf import ZeroconfServiceInfo as ZeroconfServiceInfo
 from httpx import AsyncClient as AsyncClient
 
 class PlcNetApi(Protobuf):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,8 @@ force-exclude = '.*_pb2\.py|.*\.pyi'
 [tool.isort]
 combine_as_imports = true
 filter_files = true
-ignore_whitespace = true
+forced_separate = ["tests"]
 line_length = 127
-multi_line_output = 1
-order_by_type = true
 profile = "black"
 skip_glob = "*_pb2.py"
 

--- a/tests/fixtures/device.py
+++ b/tests/fixtures/device.py
@@ -6,8 +6,8 @@ import pytest
 
 from devolo_plc_api import Device
 
-from .. import TestData
-from ..mocks.mock_zeroconf import MockServiceBrowser
+from tests import TestData
+from tests.mocks.mock_zeroconf import MockServiceBrowser
 
 
 @pytest.fixture()

--- a/tests/fixtures/device_api.py
+++ b/tests/fixtures/device_api.py
@@ -19,7 +19,7 @@ from devolo_plc_api.device_api import (
     UpdateFirmwareCheck,
 )
 
-from .. import TestData
+from tests import TestData
 
 
 @pytest_asyncio.fixture()

--- a/tests/fixtures/plcnet_api.py
+++ b/tests/fixtures/plcnet_api.py
@@ -8,7 +8,7 @@ from httpx import AsyncClient
 
 from devolo_plc_api.plcnet_api import SERVICE_TYPE, LogicalNetwork, PlcNetApi
 
-from .. import TestData
+from tests import TestData
 
 
 @pytest_asyncio.fixture()

--- a/tests/fixtures/protobuf.py
+++ b/tests/fixtures/protobuf.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator
 
 import pytest_asyncio
 
-from ..stubs.protobuf import StubProtobuf
+from tests.stubs.protobuf import StubProtobuf
 
 
 @pytest_asyncio.fixture()

--- a/tests/mocks/mock_device.py
+++ b/tests/mocks/mock_device.py
@@ -1,7 +1,7 @@
 """Mock methods from the Device class."""
 from typing import Any
 
-from .. import load_test_data
+from tests import load_test_data
 
 
 # pylint: disable=protected-access, unused-argument

--- a/tests/stubs/protobuf.py
+++ b/tests/stubs/protobuf.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 from devolo_plc_api.clients import Protobuf
 from devolo_plc_api.plcnet_api import SERVICE_TYPE
 
-from .. import load_test_data
+from tests import load_test_data
 
 
 class StubProtobuf(Protobuf):

--- a/tests/stubs/zeroconf.py
+++ b/tests/stubs/zeroconf.py
@@ -6,7 +6,7 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from devolo_plc_api.plcnet_api import SERVICE_TYPE
 
-from .. import load_test_data
+from tests import load_test_data
 
 
 class StubAsyncServiceInfo(AsyncServiceInfo):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -10,10 +10,10 @@ from devolo_plc_api.device_api import SERVICE_TYPE as DEVICEAPI, DeviceApi
 from devolo_plc_api.exceptions.device import DeviceNotFound
 from devolo_plc_api.plcnet_api import DEVICES_WITHOUT_PLCNET, SERVICE_TYPE as PLCNETAPI, PlcNetApi
 from devolo_plc_api.zeroconf import ZeroconfServiceInfo
-from tests.mocks.mock_zeroconf import MockServiceBrowser
 
 from . import TestData
 from .mocks.mock_device import state_change
+from .mocks.mock_zeroconf import MockServiceBrowser
 from .stubs.zeroconf import StubAsyncServiceInfo
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
PEP8 staits: "Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured".

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
