### PR TITLE
Switch linting to Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-profile = black
-max-complexity = 10
-max-cognitive-complexity = 5
-max-line-length = 127
-ignore = E203,E303,W503
-exclude = example_*.py,*_pb2.py

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,19 +31,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.8"
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --statistics
-    - name: Lint with pylint
-      run: |
-        python -m pip install pylint pylint-protobuf
-        python -m pip install -e .[test]
-        pylint --errors-only --score=n --load-plugins pylint_protobuf devolo_plc_api
-        pylint --exit-zero --score=n --disable=E --enable=useless-suppression --load-plugins pylint_protobuf devolo_plc_api
-        pylint --exit-zero --score=n --disable=C0103,R0801,R0903,R0904,W0212 --load-plugins pylint_protobuf tests
+        python -m pip install ruff
+        ruff check --format=github devolo_plc_api script
+        ruff check --format=github --exit-zero tests
     - name: Lint with mypy
       run: |
         python -m pip install mypy types-protobuf

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: "3.8"
     - name: Install dependencies
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: "3.8"
     - name: Lint with ruff
@@ -51,9 +51,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: ${{ matrix.python-version }}
         check-latest: true
@@ -65,7 +65,7 @@ jobs:
       run: |
         pytest --cov=devolo_plc_api
     - name: Preserve coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: coverage
         path: .coverage
@@ -76,13 +76,13 @@ jobs:
     needs: test
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: "3.8"
     - name: Download coverage
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v3.0.2
       with:
         name: coverage
     - name: Coveralls
@@ -92,6 +92,6 @@ jobs:
         export COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_TOKEN }}
         coveralls
     - name: Clean up coverage
-      uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v2.0.0
       with:
         name: coverage

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.3.0
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: "3.8"
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: '22.12.0'
+    rev: '23.1.0'
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort
-    rev: '5.11.4'
+    rev: '5.12.0'
     hooks:
         - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.3.0'
+    rev: 'v4.4.0'
     hooks:
         - id: check-json
         - id: end-of-file-fixer
         - id: trailing-whitespace
 -   repo: https://github.com/abravalheri/validate-pyproject
-    rev: 'v0.10.1'
+    rev: 'v0.12.1'
     hooks:
       - id: validate-pyproject
 -   repo: local

--- a/devolo_plc_api/clients/protobuf.py
+++ b/devolo_plc_api/clients/protobuf.py
@@ -50,7 +50,7 @@ class Protobuf(ABC):
         async_method = f"async_{attr}"
         if hasattr(self.__class__, async_method):
             return method
-        raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
+        raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")  # noqa: EM102, TRY003
 
     @property
     def url(self) -> str:
@@ -91,9 +91,9 @@ class Protobuf(ABC):
             response.raise_for_status()
         except HTTPStatusError as e:
             if e.response.status_code == HTTPStatus.UNAUTHORIZED:
-                raise DevicePasswordProtected() from None
+                raise DevicePasswordProtected from None
             raise
         except (ConnectTimeout, ConnectError, ReadTimeout, RemoteProtocolError):
-            raise DeviceUnavailable() from None
+            raise DeviceUnavailable from None
         else:
             return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,21 @@ good-names = "e,ip"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 
+[tool.ruff]
+exclude = ["*_pb2.py", "*.pyi"]
+ignore = ["ANN101", "ANN401", "COM812", "D203", "D205", "D212", "FBT", "N818", "TCH"]
+line-length = 127
+select = ["ALL"]
+target-version = "py38"
+
+[tool.ruff.isort]
+combine-as-imports = true
+forced-separate = ["tests"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["ANN201", "ARG", "PLR2004", "PT004", "PT012", "S", "SLF001"]
+"script/*" = ["INP001"]
+
 [tool.setuptools]
 packages = { find = {exclude=["docs*", "script*", "tests*"]} }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,16 +55,6 @@ skip_glob = "*_pb2.py"
 [tool.mypy]
 ignore_missing_imports = true
 
-[tool.pylint.design]
-max-attributes = 8
-
-[tool.pylint.format]
-ignore-patterns = ".*_pb2.py"
-max-line-length = 127
-
-[tool.pylint.messages_control]
-good-names = "e,ip"
-
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 

--- a/script/stubgen.py
+++ b/script/stubgen.py
@@ -2,11 +2,11 @@
 """Generate stub files for API classes with async and sync interface."""
 from __future__ import annotations
 
-import os
 import re
 import sys
 from contextlib import suppress
 from copy import copy
+from pathlib import Path
 
 from mypy.nodes import ConditionalExpr, Expression, ListExpr
 from mypy.stubgen import (
@@ -42,7 +42,7 @@ class ApiStubGenerator(StubGenerator):
             return f"list[{' | '.join(list_item_type)}]"
         return super().get_str_type_of_node(rvalue, can_infer_optional, can_be_any)
 
-    def add_sync(self):
+    def add_sync(self) -> None:
         """Add sync methods."""
         output = copy(self._output)
         for i in range(len(output)):
@@ -51,17 +51,16 @@ class ApiStubGenerator(StubGenerator):
                 self.add(output[i + 1])
                 self.add(output[i + 2])
 
-    def fix_union_annotations(self):
-        """Fix Union annotations"""
+    def fix_union_annotations(self) -> None:
+        """Fix Union annotations."""
         for i, output in enumerate(self._output):
-            match = re.search(r"Union\[([a-z, ]+)\]", output)
-            if match:
-                types = match.group(1).replace(",", " |")
-                self._output[i] = output.replace(match.group(0), types)
+            if match := re.search(r"Union\[([a-z, ]+)\]", output):
+                types = match[1].replace(",", " |")
+                self._output[i] = output.replace(match[0], types)
 
 
 def generate_stubs() -> None:
-    """Main entry point for the program."""
+    """Generate stubs - main entry point for the program."""
     options = Options(
         pyversion=sys.version_info[:2],
         no_import=True,
@@ -86,14 +85,14 @@ def generate_stubs() -> None:
     for mod in py_modules:
         target = mod.module.replace(".", "/")
         target += ".pyi"
-        target = os.path.join(options.output_dir, target)
+        target = Path(options.output_dir) / target
         files.append(target)
         with generate_guarded(mod.module, target, options.ignore_errors, options.verbose):
             generate_stub_from_ast(mod, target, options.parse_only, options.include_private, options.export_less)
 
 
 def generate_stub_from_ast(mod: StubSource, target: str, parse_only: bool, include_private: bool, export_less: bool) -> None:
-    """Use analysed (or just parsed) AST to generate type stub for single file."""
+    """Use analyzed (or just parsed) AST to generate type stub for single file."""
     gen = ApiStubGenerator(mod.runtime_all, include_private=include_private, analyzed=not parse_only, export_less=export_less)
     mod.ast.accept(gen)
     if "annotations" in mod.ast.future_import_flags:
@@ -104,11 +103,11 @@ def generate_stub_from_ast(mod: StubSource, target: str, parse_only: bool, inclu
     old_output = ""
     new_output = HEADER + "".join(gen.output())
 
-    with suppress(FileNotFoundError), open(target, "r") as file:
+    with suppress(FileNotFoundError), Path(target).open() as file:
         old_output = file.read()
 
     if new_output != old_output:
-        with open(target, "w") as file:
+        with Path(target).open("w") as file:
             file.write(new_output)
             sys.exit(1)
 


### PR DESCRIPTION
## Proposed change

Ruff now does most of the linting. I kept isort in the pre-commit to have format checking and linting in separate steps, but maybe we should rethink the structure. Ruff and isort settings of course match.

Findings Ruff had, are fixed.

I also had to update the pre-commit hooks in order to pass the CI.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
