### PR TITLE
Enable FBT rules

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ruff
-        ruff check --format=github devolo_plc_api script
+        ruff check --format=github devolo_plc_api scripts
         ruff check --format=github --exit-zero tests
     - name: Lint with mypy
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -125,11 +125,14 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 
 ### VisualStudioCode ###
-.vscode/*
+.vscode/
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
         - id: stubgen
           name: check API stub files
-          entry: script/stubgen.py
+          entry: scripts/stubgen.py
           description: check if stub files of the APIs are up-to-date
           language: script
           types: [python]

--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -56,7 +56,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
         self._password = ""
         self._session_instance: AsyncClient | None = None
         self._zeroconf_instance = zeroconf_instance
-        logging.captureWarnings(True)
+        logging.captureWarnings(capture=True)
 
         self._session: AsyncClient
         self._zeroconf: AsyncZeroconf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ asyncio_mode = "auto"
 
 [tool.ruff]
 exclude = ["*_pb2.py", "*.pyi"]
-ignore = ["ANN101", "ANN401", "COM812", "D203", "D205", "D212", "FBT", "N818", "TCH"]
+ignore = ["ANN101", "ANN401", "COM812", "D203", "D205", "D212", "FBT001", "N818", "TCH"]
 line-length = 127
 select = ["ALL"]
 target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ forced-separate = ["tests"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["ANN201", "ARG", "PLR2004", "PT004", "PT012", "S", "SLF001"]
-"script/*" = ["INP001"]
+"scripts/*" = ["INP001"]
 
 [tool.setuptools]
 packages = { find = {exclude=["docs*", "script*", "tests*"]} }

--- a/scripts/stubgen.py
+++ b/scripts/stubgen.py
@@ -29,18 +29,21 @@ isort:skip_file
 class ApiStubGenerator(StubGenerator):
     """Generate stub text from a mypy AST."""
 
-    def get_str_type_of_node(self, rvalue: Expression, can_infer_optional: bool = False, can_be_any: bool = True) -> str:
+    def get_str_type_of_node(self, rvalue: Expression, *, can_infer_optional: bool = False, can_be_any: bool = True) -> str:
         """Get type of node as string."""
         if isinstance(rvalue, ConditionalExpr):
-            if_type = self.get_str_type_of_node(rvalue.if_expr, can_infer_optional, False)
-            else_type = self.get_str_type_of_node(rvalue.else_expr, can_infer_optional, False)
+            if_type = self.get_str_type_of_node(rvalue.if_expr, can_infer_optional=can_infer_optional, can_be_any=False)
+            else_type = self.get_str_type_of_node(rvalue.else_expr, can_infer_optional=can_infer_optional, can_be_any=False)
             if if_type and else_type and if_type != else_type:
                 return f"{if_type} | {else_type}"
             return if_type or else_type or "Any" if can_be_any else ""
         if isinstance(rvalue, ListExpr):
-            list_item_type = {self.get_str_type_of_node(item, can_infer_optional, can_be_any) for item in rvalue.items}
+            list_item_type = {
+                self.get_str_type_of_node(item, can_infer_optional=can_infer_optional, can_be_any=can_be_any)
+                for item in rvalue.items
+            }
             return f"list[{' | '.join(list_item_type)}]"
-        return super().get_str_type_of_node(rvalue, can_infer_optional, can_be_any)
+        return super().get_str_type_of_node(rvalue, can_infer_optional=can_infer_optional, can_be_any=can_be_any)
 
     def add_sync(self) -> None:
         """Add sync methods."""

--- a/tests/test_deviceapi.py
+++ b/tests/test_deviceapi.py
@@ -59,14 +59,14 @@ class TestDeviceApi:
         """Test setting LED settings asynchronously."""
         led_setting_set = LedSettingsSetResponse()
         httpx_mock.add_response(content=led_setting_set.SerializeToString())
-        assert await device_api.async_set_led_setting(True)
+        assert await device_api.async_set_led_setting(enable=True)
 
     @pytest.mark.parametrize("feature", ["led"])
     def test_set_led_setting(self, device_api: DeviceApi, httpx_mock: HTTPXMock):
         """Test setting LED settings synchronously."""
         led_setting_set = LedSettingsSetResponse()
         httpx_mock.add_response(content=led_setting_set.SerializeToString())
-        assert device_api.set_led_setting(True)
+        assert device_api.set_led_setting(enable=True)
 
     @pytest.mark.asyncio()
     @pytest.mark.parametrize("feature", ["multiap"])
@@ -256,14 +256,14 @@ class TestDeviceApi:
         """Test setting wifi guest access status asynchronously."""
         wifi_guest_access_set = WifiGuestAccessSetResponse(result=WifiResult.WIFI_SUCCESS)
         httpx_mock.add_response(content=wifi_guest_access_set.SerializeToString())
-        assert await device_api.async_set_wifi_guest_access(True)
+        assert await device_api.async_set_wifi_guest_access(enable=True)
 
     @pytest.mark.parametrize("feature", ["wifi1"])
     def test_set_wifi_guest_access(self, device_api: DeviceApi, httpx_mock: HTTPXMock):
         """Test setting wifi guest access status synchronously."""
         wifi_guest_access_set = WifiGuestAccessSetResponse(result=WifiResult.WIFI_SUCCESS)
         httpx_mock.add_response(content=wifi_guest_access_set.SerializeToString())
-        assert device_api.set_wifi_guest_access(True)
+        assert device_api.set_wifi_guest_access(enable=True)
 
     @pytest.mark.asyncio()
     @pytest.mark.parametrize("feature", ["wifi1"])

--- a/tests/test_profobuf.py
+++ b/tests/test_profobuf.py
@@ -65,7 +65,7 @@ class TestProtobuf:
         await mock_device.async_connect()
         assert mock_device.device
         with pytest.raises(DevicePasswordProtected):
-            await mock_device.device.async_set_wifi_guest_access(True)
+            await mock_device.device.async_set_wifi_guest_access(enable=True)
         await mock_device.async_disconnect()
 
     @pytest.mark.asyncio()
@@ -75,7 +75,7 @@ class TestProtobuf:
         await mock_device.async_connect()
         assert mock_device.device
         with pytest.raises(DeviceUnavailable):
-            await mock_device.device.async_set_wifi_guest_access(True)
+            await mock_device.device.async_set_wifi_guest_access(enable=True)
         await mock_device.async_disconnect()
 
     @pytest.mark.asyncio()
@@ -85,7 +85,7 @@ class TestProtobuf:
         await mock_device.async_connect()
         assert mock_device.device
         with pytest.raises(HTTPStatusError):
-            await mock_device.device.async_set_wifi_guest_access(True)
+            await mock_device.device.async_set_wifi_guest_access(enable=True)
         await mock_device.async_disconnect()
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
Enable the flake8-boolean-trap rules in ruff, except for FBT001 (Boolean positional arg in function definition) as this would cause a breaking change.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [ ] Changelog is updated.
