### PR TITLE
Fix memory leak

### DIFF
--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -207,6 +207,9 @@ class Device:
         self._logger.debug("Browsing for %s", service_types)
         addr = None if self._multicast else self.ip
         question_type = DNSQuestionType.QM if self._multicast else DNSQuestionType.QU
+        if self._browser:
+            await self._browser.async_cancel()
+            self._browser = None
         self._browser = AsyncServiceBrowser(
             zeroconf=self._zeroconf.zeroconf,
             type_=service_types,

--- a/devolo_plc_api/device.py
+++ b/devolo_plc_api/device.py
@@ -50,7 +50,7 @@ class Device:
         self.plcnet: PlcNetApi | None = None
 
         self._background_tasks: set[asyncio.Task] = set()
-        self._browser: AsyncServiceBrowser | None
+        self._browser: AsyncServiceBrowser | None = None
         self._connected = False
         self._info: dict[str, ZeroconfServiceInfo] = {PLCNETAPI: ZeroconfServiceInfo(), DEVICEAPI: ZeroconfServiceInfo()}
         self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.2] - 2023/07/13
+
+### Fixed
+
+- Frequently connecting to an offline device lead to a memory leak
+
 ## [v1.3.1] - 2023/05/12
 
 ### Fixed

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -59,9 +59,11 @@ class TestDevice:
             assert get_zeroconf_info.call_count == 2
 
     @pytest.mark.asyncio()
+    @pytest.mark.parametrize("device_type", [DeviceType.PLC])
+    @pytest.mark.usefixtures("service_browser")
     async def test_async_connect_not_found(self, mock_device: Device, sleep: AsyncMock):
         """Test that an exception is raised if both APIs are not available."""
-        with patch("devolo_plc_api.device.AsyncServiceBrowser"), pytest.raises(DeviceNotFound):
+        with pytest.raises(DeviceNotFound):
             await mock_device.async_connect()
             assert not mock_device._connected
             assert sleep.call_count == Device.MDNS_TIMEOUT

--- a/tests/test_plcnetapi.py
+++ b/tests/test_plcnetapi.py
@@ -16,7 +16,7 @@ from devolo_plc_api.plcnet_api.setuserdevicename_pb2 import SetUserDeviceNameRes
 from . import DeviceType
 
 
-class TestDeviceApi:
+class TestPlcApi:
     """Test devolo_plc_api.plcnet_api.plcnetapi.PlcNetApi class."""
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
## Proposed change
Triggering the retry mechanism (e.g. by connecting to an offline device) didn't properly cancel a zeroconf browser leading to a memory leak.

Fixes #132

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
