### PR TITLE
Use zeroconf unicast requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Defining the system requirements with exact versions typically is difficult. But
 * httpx 0.21.0
 * protobuf 3.17.3
 * segno 1.5.2
-* zeroconf 0.36.8
+* zeroconf 0.70.0
 
 Other versions and even other operating systems might work. Feel free to tell us about your experience. If you want to run our unit tests, you also need:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.4.0] - 2023/07/26
 
 ### Added
 
 - Generate QR codes from wifi guest settings
+- Make use of zeroconf unicast requests to be able to respond across subnets
 
 ## [v1.3.2] - 2023/07/13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "httpx>=0.21.0",
     "protobuf>=4.22.0",
     "segno>=1.5.2",
-    "zeroconf>=0.32.0",
+    "zeroconf>=0.70.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
## Proposed change

<!--
  Please give us the big picture of your change.
-->
Newer zeroconf version allow to specify a host on service information requests. This is useful for directing requests to a specific host that may be able to respond across subnets.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
