### PR TITLE
Increase timeout of async_check_firmware_available

### DIFF
--- a/devolo_plc_api/device_api/deviceapi.py
+++ b/devolo_plc_api/device_api/deviceapi.py
@@ -208,7 +208,7 @@ class DeviceApi(Protobuf):
         """
         self._logger.debug("Checking for new firmware.")
         update_firmware_check = UpdateFirmwareCheck()
-        response = await self._async_get("UpdateFirmwareCheck")
+        response = await self._async_get("UpdateFirmwareCheck", timeout=30.0)
         update_firmware_check.ParseFromString(await response.aread())
         return update_firmware_check
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.1] - 2023/09/14
+
+### Fixed
+
+- Increase timeout of async_check_firmware_available to handle unknown errors gracefully
+
 ## [v1.4.0] - 2023/07/26
 
 ### Added


### PR DESCRIPTION
## Proposed change
<!--
  Please give us the big picture of your change.
-->
With our default timeout of 10 seconds, the device is sometime assumed to be offline when checking for new firmware. However, this call may run longer, if there are issues in devolo's update infrastructure. This MR increases the timeout to properly see an UNKNOWN_ERROR, that is not handled like a device being offline.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
