### PR TITLE
Add SPDX license identifier

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Drop support for Python 3.8
+- Use SPDX license identifier for project metadata
+
 ## [v1.4.1] - 2023/09/14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=65", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,7 +9,6 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
 ]
 description = "devolo PLC devices in Python"
@@ -23,10 +22,10 @@ dependencies = [
 dynamic = [
     "version",
 ]
-license = { file = "LICENSE" }
+license = "GPL-3.0-or-later"
 name = "devolo_plc_api"
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 urls = {changelog = "https://github.com/2Fake/devolo_plc_api/docs/CHANGELOG.md", homepage = "https://github.com/2Fake/devolo_plc_api"}
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Proposed change
Setuptools `v77` added support for [PEP 639](https://peps.python.org/pep-0639/) license expressions.
I believe the appropriate one to use here is `GPL-3.0-or-later`, the alternative would be `GPL-3.0-only`

https://spdx.org/licenses/GPL-3.0-or-later.html
https://spdx.org/licenses/GPL-3.0-only.html

Since setuptools v77 is only compatible with Python >=3.9, I needed to drop support for Python 3.8 here.

## Checklist

<!--
  In case your pull request goes to master, please have a look at the following checklist. Otherwise feel free to remove this chapter.
  Put an 'x' in the boxes that apply.
-->

- [x] Changelog is updated.
